### PR TITLE
Update Season Layout

### DIFF
--- a/ligapp/fixtures/examples.yaml
+++ b/ligapp/fixtures/examples.yaml
@@ -5,9 +5,9 @@
     last_login: null
     is_superuser: false
     username: exampleuser
-    first_name: 'Example'
-    last_name: 'User'
-    email: 'example@u.ser'
+    first_name: Example
+    last_name: User
+    email: example@u.ser
     is_staff: false
     is_active: true
     date_joined: 2022-03-03 12:27:18.243235+00:00
@@ -17,30 +17,92 @@
   pk: 1
   fields:
     name: Kento
+    user: null
 - model: ligapp.player
   pk: 2
   fields:
     name: Akane
+    user: null
 - model: ligapp.player
   pk: 3
   fields:
     name: Victor
+    user: null
+- model: ligapp.player
+  pk: 4
+  fields:
+    name: Toma
+    user: null
 - model: ligapp.player
   pk: 5
   fields:
     name: Ananas
+    user: null
 - model: ligapp.player
   pk: 6
   fields:
     name: Line
+    user: null
 - model: ligapp.player
   pk: 7
   fields:
     name: Tai
+    user: null
 - model: ligapp.player
   pk: 8
   fields:
     name: Gill
+    user: null
+- model: ligapp.player
+  pk: 9
+  fields:
+    name: Morten
+    user: null
+- model: ligapp.player
+  pk: 10
+  fields:
+    name: Marvin
+    user: null
+- model: ligapp.player
+  pk: 11
+  fields:
+    name: LohKY
+    user: null
+- model: ligapp.player
+  pk: 12
+  fields:
+    name: Pusarla
+    user: null
+- model: ligapp.player
+  pk: 13
+  fields:
+    name: Ragnarok
+    user: null
+- model: ligapp.player
+  pk: 14
+  fields:
+    name: Jenny
+    user: null
+- model: ligapp.player
+  pk: 15
+  fields:
+    name: Sabrina
+    user: null
+- model: ligapp.player
+  pk: 16
+  fields:
+    name: Pieter
+    user: null
+- model: ligapp.player
+  pk: 17
+  fields:
+    name: Lin
+    user: null
+- model: ligapp.player
+  pk: 18
+  fields:
+    name: Chen
+    user: null
 - model: ligapp.season
   pk: 1
   fields:
@@ -48,10 +110,10 @@
     start_date: 2019-08-01 00:00:00+00:00
     end_date: 2020-07-31 00:00:00+00:00
     participants:
-    - 1
     - 2
-    - 3
     - 5
+    - 1
+    - 3
     admins:
     - 1
 - model: ligapp.season
@@ -63,8 +125,22 @@
     participants:
     - 2
     - 5
+    - 18
+    - 8
+    - 14
+    - 1
+    - 17
     - 6
+    - 11
+    - 10
+    - 9
+    - 16
+    - 12
+    - 13
+    - 15
     - 7
+    - 4
+    - 3
     admins:
     - 1
 - model: ligapp.rank
@@ -96,25 +172,231 @@
   fields:
     season: 2
     player: 2
-    rank: 1
+    rank: 2
 - model: ligapp.rank
   pk: 6
   fields:
     season: 2
     player: 5
-    rank: 2
+    rank: 1
 - model: ligapp.rank
   pk: 7
   fields:
     season: 2
     player: 6
-    rank: 3
+    rank: 4
 - model: ligapp.rank
   pk: 8
   fields:
     season: 2
     player: 7
-    rank: 4
+    rank: 3
+- model: ligapp.rank
+  pk: 9
+  fields:
+    season: 2
+    player: 1
+    rank: 5
+- model: ligapp.rank
+  pk: 10
+  fields:
+    season: 2
+    player: 3
+    rank: 6
+- model: ligapp.rank
+  pk: 11
+  fields:
+    season: 2
+    player: 4
+    rank: 8
+- model: ligapp.rank
+  pk: 12
+  fields:
+    season: 2
+    player: 8
+    rank: 10
+- model: ligapp.rank
+  pk: 13
+  fields:
+    season: 2
+    player: 9
+    rank: 11
+- model: ligapp.rank
+  pk: 14
+  fields:
+    season: 2
+    player: 10
+    rank: 12
+- model: ligapp.rank
+  pk: 15
+  fields:
+    season: 2
+    player: 11
+    rank: 7
+- model: ligapp.rank
+  pk: 16
+  fields:
+    season: 2
+    player: 12
+    rank: 9
+- model: ligapp.rank
+  pk: 17
+  fields:
+    season: 2
+    player: 13
+    rank: 14
+- model: ligapp.rank
+  pk: 18
+  fields:
+    season: 2
+    player: 14
+    rank: 15
+- model: ligapp.rank
+  pk: 19
+  fields:
+    season: 2
+    player: 15
+    rank: 16
+- model: ligapp.rank
+  pk: 20
+  fields:
+    season: 2
+    player: 16
+    rank: 13
+- model: ligapp.rank
+  pk: 21
+  fields:
+    season: 2
+    player: 17
+    rank: 17
+- model: ligapp.rank
+  pk: 22
+  fields:
+    season: 2
+    player: 18
+    rank: 18
+- model: ligapp.rankinghistory
+  pk: 13
+  fields:
+    season: 2
+    player: 13
+    history:
+    - timestamp: '2022-04-16 22:11:29.551465+00:00'
+      rank: 14
+- model: ligapp.rankinghistory
+  pk: 14
+  fields:
+    season: 2
+    player: 14
+    history:
+    - timestamp: '2022-04-16 22:11:29.558147+00:00'
+      rank: 15
+- model: ligapp.rankinghistory
+  pk: 15
+  fields:
+    season: 2
+    player: 15
+    history:
+    - timestamp: '2022-04-16 22:11:29.561563+00:00'
+      rank: 16
+- model: ligapp.rankinghistory
+  pk: 16
+  fields:
+    season: 2
+    player: 16
+    history:
+    - timestamp: '2022-04-16 22:11:29.564223+00:00'
+      rank: 13
+- model: ligapp.rankinghistory
+  pk: 17
+  fields:
+    season: 2
+    player: 8
+    history:
+    - timestamp: '2022-04-16 22:15:02.017822+00:00'
+      rank: 9
+    - timestamp: '2022-04-16 22:15:59.019560+00:00'
+      rank: 10
+- model: ligapp.rankinghistory
+  pk: 18
+  fields:
+    season: 2
+    player: 9
+    history:
+    - timestamp: '2022-04-16 22:15:02.020658+00:00'
+      rank: 10
+    - timestamp: '2022-04-16 22:15:59.022001+00:00'
+      rank: 11
+- model: ligapp.rankinghistory
+  pk: 19
+  fields:
+    season: 2
+    player: 10
+    history:
+    - timestamp: '2022-04-16 22:15:02.023005+00:00'
+      rank: 11
+    - timestamp: '2022-04-16 22:15:59.024521+00:00'
+      rank: 12
+- model: ligapp.rankinghistory
+  pk: 20
+  fields:
+    season: 2
+    player: 11
+    history:
+    - timestamp: '2022-04-16 22:15:02.025432+00:00'
+      rank: 12
+    - timestamp: '2022-04-16 22:15:59.027920+00:00'
+      rank: 7
+- model: ligapp.rankinghistory
+  pk: 21
+  fields:
+    season: 2
+    player: 12
+    history:
+    - timestamp: '2022-04-16 22:15:02.028817+00:00'
+      rank: 8
+    - timestamp: '2022-04-16 22:15:59.016709+00:00'
+      rank: 9
+- model: ligapp.rankinghistory
+  pk: 22
+  fields:
+    season: 2
+    player: 4
+    history:
+    - timestamp: '2022-04-16 22:15:59.010759+00:00'
+      rank: 8
+- model: ligapp.rankinghistory
+  pk: 23
+  fields:
+    season: 2
+    player: 6
+    history:
+    - timestamp: '2022-04-16 22:18:07.714891+00:00'
+      rank: 4
+- model: ligapp.rankinghistory
+  pk: 24
+  fields:
+    season: 2
+    player: 7
+    history:
+    - timestamp: '2022-04-16 22:18:07.717820+00:00'
+      rank: 3
+- model: ligapp.rankinghistory
+  pk: 25
+  fields:
+    season: 2
+    player: 2
+    history:
+    - timestamp: '2022-04-16 22:18:42.902017+00:00'
+      rank: 2
+- model: ligapp.rankinghistory
+  pk: 26
+  fields:
+    season: 2
+    player: 5
+    history:
+    - timestamp: '2022-04-16 22:18:42.904938+00:00'
+      rank: 1
 - model: ligapp.match
   pk: 1
   fields:
@@ -150,6 +432,62 @@
     first_player: 7
     second_player: 2
     season: 2
+- model: ligapp.match
+  pk: 29
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 16
+    second_player: 13
+    season: 2
+- model: ligapp.match
+  pk: 30
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 15
+    second_player: 14
+    season: 2
+- model: ligapp.match
+  pk: 31
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 12
+    second_player: 8
+    season: 2
+- model: ligapp.match
+  pk: 32
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 11
+    second_player: 4
+    season: 2
+- model: ligapp.match
+  pk: 33
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 10
+    second_player: 3
+    season: 2
+- model: ligapp.match
+  pk: 34
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 9
+    second_player: 1
+    season: 2
+- model: ligapp.match
+  pk: 35
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 7
+    second_player: 6
+    season: 2
+- model: ligapp.match
+  pk: 36
+  fields:
+    date_played: 2020-12-18 00:00:00+00:00
+    first_player: 5
+    second_player: 2
+    season: 2
 - model: ligapp.timedmatch
   pk: 1
   fields:
@@ -164,12 +502,34 @@
     minutes_played: 9
 - model: ligapp.multisetmatch
   pk: 5
-  fields:
-    season: 2
+  fields: {}
 - model: ligapp.multisetmatch
   pk: 6
-  fields:
-    season: 2
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 29
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 30
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 31
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 32
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 33
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 34
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 35
+  fields: {}
+- model: ligapp.multisetmatch
+  pk: 36
+  fields: {}
 - model: ligapp.set
   pk: 1
   fields:
@@ -213,6 +573,13 @@
     match: 6
     order: 1
 - model: ligapp.set
+  pk: 9
+  fields:
+    first_score: 21
+    second_score: 16
+    match: 6
+    order: 3
+- model: ligapp.set
   pk: 10
   fields:
     first_score: 24
@@ -220,9 +587,135 @@
     match: 6
     order: 2
 - model: ligapp.set
-  pk: 9
+  pk: 33
+  fields:
+    first_score: 21
+    second_score: 13
+    match: 29
+    order: 1
+- model: ligapp.set
+  pk: 34
+  fields:
+    first_score: 21
+    second_score: 18
+    match: 29
+    order: 2
+- model: ligapp.set
+  pk: 35
+  fields:
+    first_score: 15
+    second_score: 21
+    match: 30
+    order: 1
+- model: ligapp.set
+  pk: 36
+  fields:
+    first_score: 21
+    second_score: 12
+    match: 30
+    order: 2
+- model: ligapp.set
+  pk: 37
+  fields:
+    first_score: 19
+    second_score: 21
+    match: 30
+    order: 3
+- model: ligapp.set
+  pk: 38
+  fields:
+    first_score: 21
+    second_score: 11
+    match: 31
+    order: 1
+- model: ligapp.set
+  pk: 39
+  fields:
+    first_score: 21
+    second_score: 2
+    match: 31
+    order: 2
+- model: ligapp.set
+  pk: 40
+  fields:
+    first_score: 21
+    second_score: 19
+    match: 32
+    order: 1
+- model: ligapp.set
+  pk: 41
+  fields:
+    first_score: 19
+    second_score: 21
+    match: 32
+    order: 2
+- model: ligapp.set
+  pk: 42
+  fields:
+    first_score: 25
+    second_score: 23
+    match: 32
+    order: 3
+- model: ligapp.set
+  pk: 43
+  fields:
+    first_score: 5
+    second_score: 21
+    match: 33
+    order: 1
+- model: ligapp.set
+  pk: 44
+  fields:
+    first_score: 7
+    second_score: 21
+    match: 33
+    order: 2
+- model: ligapp.set
+  pk: 45
+  fields:
+    first_score: 17
+    second_score: 21
+    match: 34
+    order: 1
+- model: ligapp.set
+  pk: 46
+  fields:
+    first_score: 13
+    second_score: 21
+    match: 34
+    order: 2
+- model: ligapp.set
+  pk: 47
   fields:
     first_score: 21
     second_score: 16
-    match: 6
+    match: 35
+    order: 1
+- model: ligapp.set
+  pk: 48
+  fields:
+    first_score: 21
+    second_score: 19
+    match: 35
+    order: 2
+- model: ligapp.set
+  pk: 49
+  fields:
+    first_score: 19
+    second_score: 21
+    match: 36
+    order: 1
+- model: ligapp.set
+  pk: 50
+  fields:
+    first_score: 21
+    second_score: 14
+    match: 36
+    order: 2
+- model: ligapp.set
+  pk: 51
+  fields:
+    first_score: 21
+    second_score: 16
+    match: 36
     order: 3

--- a/ligapp/static/ligapp/style.css
+++ b/ligapp/static/ligapp/style.css
@@ -129,11 +129,11 @@ form.player-item{
   grid-template-rows: 100px;
 }
 
-.action-grid .btn i {
+.action-grid .btn.action i {
   font-size: 24pt;
 }
 
-.action-grid .btn p {
+.action-grid .btn.action {
   font-size: 10pt;
   line-height: normal;
 }

--- a/ligapp/static/ligapp/style.css
+++ b/ligapp/static/ligapp/style.css
@@ -10,6 +10,39 @@
   background-color: #ddd;
 }
 
+.matchlist {
+  min-width: 220px;
+  padding-left: inherit;
+}
+
+.match {
+  background-color: #dfeeff;
+  border-color: #fff;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 4px;
+  padding-right: 10px;
+  text-decoration: inherit;
+  color: inherit;
+}
+
+.match-player {
+}
+
+.match-winner {
+  font-weight: bold;
+}
+
+.match-data {
+}
+
+.match-score {
+  min-width: 2rem;
+  text-align: right;
+  padding-left: .5rem;
+  padding-right: .5rem;
+}
+
 .match-list {
   display: block;
   overflow-x: auto;
@@ -87,7 +120,69 @@ form.player-item{
   border: none;
 }
 
-@keyframes hide {
-  from {display: "";}
-  to {display: "none";}
+.action-grid {
+  display: grid;
+  gap: 1rem 1rem;
+  padding: 0rem 0rem 1rem 0rem;
+  grid-auto-flow: row;
+  grid-template-columns: 100px 100px 100px 100px 100px 100px 100px 100px;
+  grid-template-rows: 100px;
+}
+
+.action-grid .btn i {
+  font-size: 24pt;
+}
+
+.action-grid .btn p {
+  font-size: 10pt;
+  line-height: normal;
+}
+
+.section-title, .panel-title {
+  padding-left: 0px;
+}
+
+.season-panel {
+  padding-top: 10px;
+  padding-left: calc(var(--bs-gutter-x) * .5);
+  margin-left: calc(-.5 * var(--bs-gutter-x));
+  margin-right: calc(.5 * var(--bs-gutter-x));
+}
+
+.season-panel ul.list-group-flush {
+  padding-left: 0px;
+}
+
+@media only screen and (max-width: 991px) {
+  [class="action-grid"] {
+    grid-template-columns: 100px 100px 100px 100px 100px 100px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  [class="action-grid"] {
+    grid-template-columns: 100px 100px 100px 100px;
+  }
+}
+
+@media only screen and (max-width: 512px) {
+  [class="action-grid"] {
+    grid-template-columns: 100px 100px 100px;
+  }
+}
+
+@media only screen and (max-width: 370px) {
+  [class="action-grid"] {
+    grid-template-columns: 100px 100px;
+  }
+}
+
+.season-section {
+  margin-left: calc(-.5 * var(--bs-gutter-x));
+}
+
+@media only screen and (max-width: 568px) {
+  .season-section, #season-header {
+    margin-left: 0px;
+  }
 }

--- a/ligapp/templates/ligapp/add_player_form.html
+++ b/ligapp/templates/ligapp/add_player_form.html
@@ -1,9 +1,11 @@
-{% extends "base.html" %}
+{% extends "ligapp/season_base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %} Ligapp - Add a Player {% endblock %}
-{% block pagetitle %} Add a player {% endblock %}
+{% block season_actions_section %}{% endblock %}
 
-{% block content %}
-{% crispy form %}
+{% block season_content %}
+<div class="row season-section" id="season-add-player" style>
+  <h4 class="section-title">Add a Player</h4><hr>
+  {% crispy form %}
+</div>
 {% endblock %}

--- a/ligapp/templates/ligapp/new_match_form.html
+++ b/ligapp/templates/ligapp/new_match_form.html
@@ -1,9 +1,11 @@
-{% extends "base.html" %}
+{% extends "ligapp/season_base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %} Ligapp - Create new match {% endblock %}
-{% block pagetitle %} Create new match {% endblock %}
+{% block season_actions_section %}{% endblock %}
 
-{% block content %}
-{% crispy form %}
+{% block season_content %}
+<div class="row season-section" id="season-new-match" style>
+  <h4 class="section-title">Create New Match</h4><hr>
+  {% crispy form %}
+</div>
 {% endblock %}

--- a/ligapp/templates/ligapp/season_base.html
+++ b/ligapp/templates/ligapp/season_base.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% load l10n %}
+{% load match %}
+{% load bootstrap %}
+
+{% block title %}{{ season.name }}{% endblock %}
+{% block pagetitle %}{{ season.name }}{% endblock %}
+
+{% block content %}
+
+  <div class="row" id="season-header">
+    Started: {{ season.start_date.date | localize }};
+    {% if season.end_date %}
+      Closed: {{ season.end_date.date | localize }}
+    {% else %}
+      Still running
+    {% endif %}
+  </div>
+
+  {% block season_actions_section %}
+  <div class="row season-section" id="season-actions">
+    <h4 class="section-title">Season Actions</h4> <hr>
+
+    <div class="action-grid">
+      {% block season_actions %}
+      <a id="button-add-player" class="btn btn-sm btn-outline-primary" href={% url "ligapp:add-player" season=season.pk %}>
+        <i class="bi bi-person-plus"></i><p>Add Player</p>
+      </a>
+
+      <a id="button-view-players" class="btn btn-sm btn-outline-primary" href={% url "ligapp:season-ranking" pk=season.pk %}>
+        <i class="bi bi-file-person"></i><p>Full Ranking</p>
+      </a>
+
+      <a id="button-new-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match" season=season.pk %}>
+        <i class="bi bi-clipboard-plus" ></i><p >New Match</p>
+      </a>
+
+      <a id="button-view-matches" class="btn btn-sm btn-outline-primary" href={% url "ligapp:season-match-history" pk=season.pk %}>
+        <i class="bi bi-clipboard-data" ></i><p >Match History</p>
+      </a>
+      {% endblock %}
+
+      {% block local_actions %}{% endblock %}
+    </div>
+  </div>
+  {% endblock %}
+
+  {% block season_content %}{% endblock %}
+
+{% endblock %}
+
+{% block sidebarlinks %}
+<li class="nav-item text-white">{{ season.name }}<li>
+<ul>
+  <li class="nav-item">
+    <a class="nav-link" href={% url "ligapp:season-detail" pk=season.pk %}><i class="bi bi-grid"></i> Season Overview</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href={% url "ligapp:add-player" season=season.pk %}><i class="bi bi-person-plus"></i> Add Player</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href={% url "ligapp:season-ranking" pk=season.pk %}><i class="bi bi-file-person"></i> Full Ranking</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href={% url "ligapp:new-match" season=season.pk %}><i class="bi bi-clipboard-plus"></i> New Match</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href={% url "ligapp:season-match-history" pk=season.pk %}><i class="bi bi-clipboard-data"></i> Match History</a>
+  </li>
+</ul>
+{% endblock %}

--- a/ligapp/templates/ligapp/season_base.html
+++ b/ligapp/templates/ligapp/season_base.html
@@ -23,17 +23,25 @@
 
     <div class="action-grid">
       {% block season_actions %}
+      {% if user in season.admins.all or user.is_staff %}
       <a id="button-add-player" class="btn btn-sm btn-outline-primary" href={% url "ligapp:add-player" season=season.pk %}>
         <i class="bi bi-person-plus"></i><p>Add Player</p>
       </a>
+      {% endif %}
 
       <a id="button-view-players" class="btn btn-sm btn-outline-primary" href={% url "ligapp:season-ranking" pk=season.pk %}>
         <i class="bi bi-file-person"></i><p>Full Ranking</p>
       </a>
 
+      {% if user in season.admins.all or user.is_staff %}
       <a id="button-new-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match" season=season.pk %}>
         <i class="bi bi-clipboard-plus" ></i><p >New Match</p>
       </a>
+      {% elif user.player in season.participants.all %}
+      <a id="button-new-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match-as-player" player=user.player.pk season=season.pk %}>
+        <i class="bi bi-clipboard-plus" ></i><p >New Match</p>
+      </a>
+      {% endif %}
 
       <a id="button-view-matches" class="btn btn-sm btn-outline-primary" href={% url "ligapp:season-match-history" pk=season.pk %}>
         <i class="bi bi-clipboard-data" ></i><p >Match History</p>

--- a/ligapp/templates/ligapp/season_base.html
+++ b/ligapp/templates/ligapp/season_base.html
@@ -24,27 +24,27 @@
     <div class="action-grid">
       {% block season_actions %}
       {% if user in season.admins.all or user.is_staff %}
-      <a id="button-add-player" class="btn btn-sm btn-outline-primary" href={% url "ligapp:add-player" season=season.pk %}>
-        <i class="bi bi-person-plus"></i><p>Add Player</p>
+      <a id="button-add-player" class="action btn btn-sm btn-outline-primary" href='{% url "ligapp:add-player" season=season.pk %}'>
+        <i class="bi bi-person-plus"></i><br>Add Player
       </a>
       {% endif %}
 
-      <a id="button-view-players" class="btn btn-sm btn-outline-primary" href={% url "ligapp:season-ranking" pk=season.pk %}>
-        <i class="bi bi-file-person"></i><p>Full Ranking</p>
+      <a id="button-view-ranking" class="action btn btn-sm btn-outline-primary" href='{% url "ligapp:season-ranking" pk=season.pk %}'>
+        <i class="bi bi-file-person"></i><br>Full Ranking
       </a>
 
       {% if user in season.admins.all or user.is_staff %}
-      <a id="button-new-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match" season=season.pk %}>
-        <i class="bi bi-clipboard-plus" ></i><p >New Match</p>
+      <a id="button-new-match" class="action btn btn-sm btn-outline-primary" href='{% url "ligapp:new-match" season=season.pk %}'>
+        <i class="bi bi-clipboard-plus" ></i><br>New Match
       </a>
       {% elif user.player in season.participants.all %}
-      <a id="button-new-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match-as-player" player=user.player.pk season=season.pk %}>
-        <i class="bi bi-clipboard-plus" ></i><p >New Match</p>
+      <a id="button-new-match" class="action btn btn-sm btn-outline-primary" href='{% url "ligapp:new-match-as-player" player=user.player.pk season=season.pk %}'>
+        <i class="bi bi-clipboard-plus" ></i><br>New Match
       </a>
       {% endif %}
 
-      <a id="button-view-matches" class="btn btn-sm btn-outline-primary" href={% url "ligapp:season-match-history" pk=season.pk %}>
-        <i class="bi bi-clipboard-data" ></i><p >Match History</p>
+      <a id="button-view-matches" class="action btn btn-sm btn-outline-primary" href='{% url "ligapp:season-match-history" pk=season.pk %}'>
+        <i class="bi bi-clipboard-data" ></i><br>Match History
       </a>
       {% endblock %}
 
@@ -61,19 +61,19 @@
 <li class="nav-item text-white">{{ season.name }}<li>
 <ul>
   <li class="nav-item">
-    <a class="nav-link" href={% url "ligapp:season-detail" pk=season.pk %}><i class="bi bi-grid"></i> Season Overview</a>
+    <a class="nav-link" id="nav-season-overview" href='{% url "ligapp:season-detail" pk=season.pk %}'><i class="bi bi-grid"></i> Season Overview</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href={% url "ligapp:add-player" season=season.pk %}><i class="bi bi-person-plus"></i> Add Player</a>
+    <a class="nav-link" id="nav-season-add-player" href='{% url "ligapp:add-player" season=season.pk %}'><i class="bi bi-person-plus"></i> Add Player</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href={% url "ligapp:season-ranking" pk=season.pk %}><i class="bi bi-file-person"></i> Full Ranking</a>
+    <a class="nav-link" id="nav-season-view-ranking" href='{% url "ligapp:season-ranking" pk=season.pk %}'><i class="bi bi-file-person"></i> Full Ranking</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href={% url "ligapp:new-match" season=season.pk %}><i class="bi bi-clipboard-plus"></i> New Match</a>
+    <a class="nav-link" id="nav-season-new-match" href='{% url "ligapp:new-match" season=season.pk %}'><i class="bi bi-clipboard-plus"></i> New Match</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href={% url "ligapp:season-match-history" pk=season.pk %}><i class="bi bi-clipboard-data"></i> Match History</a>
+    <a class="nav-link" id="nav-season-view-matches" href='{% url "ligapp:season-match-history" pk=season.pk %}'><i class="bi bi-clipboard-data"></i> Match History</a>
   </li>
 </ul>
 {% endblock %}

--- a/ligapp/templates/ligapp/season_detail.html
+++ b/ligapp/templates/ligapp/season_detail.html
@@ -1,77 +1,42 @@
-{% extends "base.html" %}
+{% extends "ligapp/season_base.html" %}
 {% load l10n %}
 {% load match %}
 {% load bootstrap %}
 
-{% block title %}{{ season.name }}{% endblock %}
-{% block pagetitle %}{{ season.name }}{% endblock %}
+{% block season_content %}
 
-{% block content %}
-<div class="container">
+<div class="row row-cols-auto season-section" id="season-overview" style>
 
-    <div class="accordion">
-
-      <div class="accordion-item">
-        <div class="accordion-header">
-        <button {% accordion-button-props "info" "h2" %}>
-            Info
-          </button>
+  <div class="col season-panel flex-fill" id="season-latest-matches">
+    <h4 class="panel-title">Latest Matches</h4><hr>
+    <div class="matchlist">
+      {% for date, matches in season.latest_matches %}
+      <div class="match-date row">{{ date | localize }}</div>
+      {% for match in matches %}
+      <a class="match row" href={% url "ligapp:match-detail" pk=match.pk %}>
+        <div class="match-data col-3">
+          <div class="match-player{% if match.child.winner.pk == match.first_player.pk %} match-winner{% endif %}">{{ match.first_player }}</div>
+          <div class="match-player{% if match.child.winner.pk == match.second_player.pk %} match.winner{% endif %}">{{match.second_player}}</div>
         </div>
-
-        <ul {% accordion-body-props "info" "list-group-flush" %}>
-          <li class="list-group-item">{{ season.start_date.date | localize }} - {{ season.end_date_str.date | localize }}</li>
-        </ul>
-      </div>
-
-      <div class="accordion-item">
-        <div class="accordion-header">
-        <button {% accordion-button-props "participants" "h2" %}>
-            Participants
-          </button>
-        </div>
-
-        <div {% accordion-body-props "participants" "player-list-grid" %}>
-          {% for participant in season.participants.all %}
-          <div class="player-item">{{ participant.name }}</div>
-          {% endfor %}
-          <a id="button-show-add-player" class="player-item btn btn-sm btn-outline-primary" href={% url "ligapp:add-player" season=season.pk %}>
-            <i class="bi bi-person-plus"></i>
-          </a>
-        </div>
-      </div>
-
-      <div class="accordion-item">
-        <div class="accordion-header">
-          <button {% accordion-button-props "matches" "h2" %}>
-            Matches
-          </button>
-        </div>
-        <div {% accordion-body-props "matches"%}>
-          {% if user in season.admins.all or user.is_staff %}
-          <a id="button-add-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match" season=season.pk %}>
-            <i class="bi bi-plus"></i> Add new match
-          </a>
-          {% elif user.player in season.participants.all %}
-          <a id="button-add-match" class="btn btn-sm btn-outline-primary" href={% url "ligapp:new-match-as-player" season=season.pk player=user.player.pk %}>
-            <i class="bi bi-plus"></i> Add new match
-          </a>
-          {% endif %}
-          {% match_list season.matches "matchlist"%}
-        </div>
-      </div>
-
-      <div class="accordion-item">
-        <div class="accordion-header">
-          <button {% accordion-button-props "ranking" "h2" %}>Ranking</button>
-        </div>
-        <ul {% accordion-body-props "ranking" "list-group-flush" %}>
-          {% for rank in season.ranks.all %}
-          <li class="list-group-item">{{ rank.rank }}. {{ rank.player }}</li>
-          {% endfor %}
-        </ul>
-      </div>
-
+        <div class="match-data flex-fill col-1">{% if match.child.minutes_played %}{{ match.child.minutes_played }}'{% endif %}</div>
+        {% for set in match.sets.all %}
+        <div class="match-data match-score col-1">{{ set.first_score }}<br>{{ set.second_score }}</div>
+        {% endfor %}
+      </a>
+      {% endfor %}
+      {% endfor %}
     </div>
+  </div>
+
+  <div class="col season-panel flex-fill" id="season-ranking">
+    <h4 class="panel-title">Ranking Top 16</h4><hr>
+    <ul class="list-group-flush">
+        {% for rank in season.top_16 %}
+        <li class="list-group-item">{{ rank.rank }}. {{ rank.player }}</li>
+        {% endfor %}
+    </ul>
+  </div>
 
 </div>
+
 {% endblock %}

--- a/ligapp/templates/ligapp/season_detail.html
+++ b/ligapp/templates/ligapp/season_detail.html
@@ -14,11 +14,11 @@
       <div class="match-date row">{{ date | localize }}</div>
       {% for match in matches %}
       <a class="match row" href={% url "ligapp:match-detail" pk=match.pk %}>
-        <div class="match-data col-3">
+        <div class="match-data match-players col-3">
           <div class="match-player{% if match.child.winner.pk == match.first_player.pk %} match-winner{% endif %}">{{ match.first_player }}</div>
           <div class="match-player{% if match.child.winner.pk == match.second_player.pk %} match.winner{% endif %}">{{match.second_player}}</div>
         </div>
-        <div class="match-data flex-fill col-1">{% if match.child.minutes_played %}{{ match.child.minutes_played }}'{% endif %}</div>
+        <div class="match-data match-duration flex-fill col-1">{% if match.child.minutes_played %}{{ match.child.minutes_played }}'{% endif %}</div>
         {% for set in match.sets.all %}
         <div class="match-data match-score col-1">{{ set.first_score }}<br>{{ set.second_score }}</div>
         {% endfor %}

--- a/ligapp/templates/ligapp/season_detail.html
+++ b/ligapp/templates/ligapp/season_detail.html
@@ -16,7 +16,7 @@
       <a class="match row" href={% url "ligapp:match-detail" pk=match.pk %}>
         <div class="match-data match-players col-3">
           <div class="match-player{% if match.child.winner.pk == match.first_player.pk %} match-winner{% endif %}">{{ match.first_player }}</div>
-          <div class="match-player{% if match.child.winner.pk == match.second_player.pk %} match.winner{% endif %}">{{match.second_player}}</div>
+          <div class="match-player{% if match.child.winner.pk == match.second_player.pk %} match-winner{% endif %}">{{match.second_player}}</div>
         </div>
         <div class="match-data match-duration flex-fill col-1">{% if match.child.minutes_played %}{{ match.child.minutes_played }}'{% endif %}</div>
         {% for set in match.sets.all %}

--- a/ligapp/templates/ligapp/season_match_history.html
+++ b/ligapp/templates/ligapp/season_match_history.html
@@ -1,0 +1,35 @@
+{% extends "ligapp/season_base.html" %}
+{% load l10n %}
+{% load match %}
+{% load bootstrap %}
+
+{% block season_actions_section %}{% endblock %}
+
+{% block season_content %}
+<div class="row season-section" id="season-full-ranking" style>
+  <h4 class="section-title">Full Match History</h4><hr>
+  <div class="matchlist">
+    {% for date, matches in season.match_history %}
+    <div class="match-date row">{{ date | localize }}</div>
+    {% for match in matches %}
+    <a class="match row" href={% url "ligapp:match-detail" pk=match.pk %}>
+      <div class="match-data col-3">
+        <div class="match-player{% if match.child.winner.pk == match.first_player.pk %} match-winner{% endif %}">{{ match.first_player }}</div>
+        <div class="match-player{% if match.child.winner.pk == match.second_player.pk %} match.winner{% endif %}">{{match.second_player}}</div>
+      </div>
+      <div class="match-data flex-fill col-1">{% if match.child.minutes_played %}{{ match.child.minutes_played }}'{% endif %}</div>
+      {% for set in match.sets.all %}
+      <div class="match-data match-score col-1">{{ set.first_score }}<br>{{ set.second_score }}</div>
+      {% endfor %}
+    </a>
+    {% endfor %}
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}
+
+{% block sidebarlinks %}
+<li class="nav-item">
+  <a class="nav-link" href={% url "ligapp:season-detail" pk=season.pk %}><i class="bi bi-grid"></i> Season Overview</a>
+</li>
+{% endblock %}

--- a/ligapp/templates/ligapp/season_ranking.html
+++ b/ligapp/templates/ligapp/season_ranking.html
@@ -1,0 +1,17 @@
+{% extends "ligapp/season_base.html" %}
+{% load l10n %}
+{% load match %}
+{% load bootstrap %}
+
+{% block season_actions_section %}{% endblock %}
+
+{% block season_content %}
+<div class="row season-section" id="season-full-ranking" style>
+  <h4 class="section-title">Full Ranking</h4><hr>
+  <ul class="list-group-flush">
+      {% for rank in season.ranks.all %}
+      <li class="list-group-item">{{ rank.rank }}. {{ rank.player }}</li>
+      {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/ligapp/templates/match_item.html
+++ b/ligapp/templates/match_item.html
@@ -15,5 +15,5 @@
   <td class="match-vs">vs.</td>
   <td class="match-player"><span {% if match.child.winner.pk == match.second_player.pk %}class="winner"{% endif %}>{{ match.second_player }}</span></td>
   <td class="match-score">{{ match.score_str }}</td>
-  <td class="match-detail-link"><a href="{% url "ligapp:match-detail" match.pk %}">details</a><td>
+  <td class="match-detail-link"><a href="{% url "ligapp:match-detail" match.pk %}"><i class="bi bi-eye"></i></a><td>
 </tr>

--- a/ligapp/urls.py
+++ b/ligapp/urls.py
@@ -7,6 +7,16 @@ app_name = "ligapp"
 urlpatterns = [
     path("", views.SeasonListView.as_view(), name="index"),
     path("season/<int:pk>/", views.SeasonDetailView.as_view(), name="season-detail"),
+    path(
+        "season/<int:pk>/ranking",
+        views.SeasonRankingView.as_view(),
+        name="season-ranking",
+    ),
+    path(
+        "season/<int:pk>/match-history",
+        views.SeasonMatchHistoryView.as_view(),
+        name="season-match-history",
+    ),
     path("add-season/", views.CreateSeasonView.as_view(), name="add-season"),
     path("match/<int:pk>/", views.MatchDetailView.as_view(), name="match-detail"),
     path("add-player/", views.SeasonListView.as_view(), name="add-player"),

--- a/ligapp/views.py
+++ b/ligapp/views.py
@@ -26,6 +26,22 @@ class SeasonDetailView(LoginRequiredMixin, DetailView):
     context_object_name = "season"
 
 
+class SeasonRankingView(LoginRequiredMixin, DetailView):
+    """Display the full ranking of the season."""
+
+    model = Season
+    template_name = "ligapp/season_ranking.html"
+    context_object_name = "season"
+
+
+class SeasonMatchHistoryView(LoginRequiredMixin, DetailView):
+    """Display the full match history of the season."""
+
+    model = Season
+    template_name = "ligapp/season_match_history.html"
+    context_object_name = "season"
+
+
 class MatchDetailView(LoginRequiredMixin, DetailView):
     """Display a match."""
 

--- a/tests/add_player.feature
+++ b/tests/add_player.feature
@@ -8,7 +8,6 @@ Feature: Add Player
     And I enter the name of a new player and submit
 
     Then I should be redirected to the season detail page
-    And the new player should be listed
     And the ranking should be updated with the new player
 
   Scenario: Add an existing player to a season
@@ -19,5 +18,4 @@ Feature: Add Player
     And I enter the name of an existing player and submit
 
     Then I should be redirected to the season detail page
-    And the added existing player should be listed
     And the ranking should be updated with the added existing player

--- a/tests/new_match.feature
+++ b/tests/new_match.feature
@@ -10,7 +10,6 @@ Feature: New Match
 
     Then I should be redirected to the season detail page
     And The new match should be in the list
-    #And The ranking should be updated
 
   Scenario: Add a new fixed duration match to an existing season
     Given I am logged in on the season list
@@ -22,19 +21,6 @@ Feature: New Match
 
     Then I should be redirected to the season detail page
     And The new fixed duration match should be in the list
-    #And The ranking should be updated
-
-  Scenario: Add a new fixed duration match to an existing season
-    Given I am logged in on the season list
-    And I am season admin for the test season
-
-    When I browse to the first season in the list
-    And I click to add a match
-    And I enter valid data for a fixed duration match and submit
-
-    Then I should be redirected to the season detail page
-    And The new fixed duration match should be in the list
-    And The ranking should be updated
 
   Scenario: Cancel adding a new match
     Given I am logged in on the season list
@@ -45,7 +31,6 @@ Feature: New Match
     And I click cancel
 
     Then I should be redirected to the season detail page
-    #And The ranking should be unchanged
 
   Scenario: Season only shows up for admin
     Given I am logged in on the season list as nonadmin

--- a/tests/test_add_player.py
+++ b/tests/test_add_player.py
@@ -19,7 +19,7 @@ def test_existing_player(
 
 @when("I click to add a player")
 def click_add_player(authbrowser):
-    authbrowser.find_by_css(".bi-person-plus").click()
+    authbrowser.find_by_id("button-add-player").click()
 
 
 @when("I enter the name of a new player and submit")
@@ -40,16 +40,6 @@ def type_existing_name_submit(authbrowser):
     christo = [option for option in options if option.text == "Christo"][0]
     christo.click()
     authbrowser.find_by_name("submit").first.click()
-
-
-@then("the new player should be listed")
-def new_player_listed(authbrowser):
-    assert authbrowser.find_by_text("Toma")
-
-
-@then("the added existing player should be listed")
-def added_player_listed(authbrowser):
-    assert authbrowser.find_by_text("Christo")
 
 
 @then("the ranking should be updated with the new player")

--- a/tests/test_new_match.py
+++ b/tests/test_new_match.py
@@ -45,7 +45,7 @@ def browse_to_seasons_list(
 @when("I click to add a match")
 def click_add_match(authbrowser):
     assert not authbrowser.find_by_text("Kento vs. Victor")
-    authbrowser.find_link_by_partial_text("new match").click()
+    authbrowser.find_by_id("button-new-match").click()
 
 
 @when("I enter valid data and submit")
@@ -66,9 +66,9 @@ def enter_valid_match_data(authbrowser):
 @when("I enter valid data for a fixed duration match and submit")
 def enter_valid_timed_match_data(authbrowser):
     authbrowser.find_by_id("select2-id_first_player-container").first.click()
-    authbrowser.find_by_css(".select2-search__field").type("Ken" + Keys.RETURN)
-    authbrowser.find_by_id("select2-id_second_player-container").first.click()
     authbrowser.find_by_css(".select2-search__field").type("Vic" + Keys.RETURN)
+    authbrowser.find_by_id("select2-id_second_player-container").first.click()
+    authbrowser.find_by_css(".select2-search__field").type("Ken" + Keys.RETURN)
     authbrowser.select("match_type", "Time")
     authbrowser.fill("minutes_played", "10")
     authbrowser.fill("date_played", "1.4.2020")
@@ -86,44 +86,41 @@ def cancel_new_match(authbrowser):
 def new_match_in_list(
     authbrowser,
 ):
-    new_match = authbrowser.find_by_css(".match-item").first
+    matches = authbrowser.find_by_css(".match")
+    new_match = None
+    for match in matches:
+        players = match.find_by_css(".match-players")
+        if players.text == "Kento\nVictor":
+            new_match = match
+            break
     assert new_match
-    assert new_match.find_by_text("March 1, 2020")
-    assert new_match.find_by_text("Kento")
-    assert new_match.find_by_text("Victor")
-    assert new_match.find_by_text("21 : 19, 21 : 11")
+    scores = [i.text for i in new_match.find_by_css(".match-score")]
+    assert scores == ["21\n19", "21\n11"]
 
 
 @then("The new fixed duration match should be in the list")
 def new_timed_match_in_list(
     authbrowser,
 ):
-    new_match = authbrowser.find_by_css(".match-item").last
+    matches = authbrowser.find_by_css(".match")
+    new_match = None
+    for match in matches:
+        players = match.find_by_css(".match-players")
+        if players.text == "Victor\nKento":
+            new_match = match
+            break
     assert new_match
-    assert new_match.find_by_text("April 1, 2020")
-    assert new_match.find_by_text("Kento")
-    assert new_match.find_by_text("Victor")
-    assert new_match.find_by_css(".match-duration").text == "10 minutes"
-    assert new_match.find_by_text("54 : 32")
+    assert new_match.find_by_css(".match-duration").first.text == "10'"
+    scores = [i.text for i in new_match.find_by_css(".match-score")]
+    assert scores == ["54\n32"]
 
 
 @then("I should not see the add match button")
 def no_add_match(nonadmin_authbrowser):
-    assert not nonadmin_authbrowser.find_link_by_partial_text("new match")
+    assert not nonadmin_authbrowser.find_by_id("button-new-match")
+    assert not nonadmin_authbrowser.find_link_by_text("New Match")
 
 
 @then("I should not see any seasons")
 def season_not_in_list(nonadmin_authbrowser, season_name):
     assert not nonadmin_authbrowser.links.find_by_text(season_name)
-
-
-@then("The ranking should be updated")
-def ranking_updated(authbrowser):
-    assert authbrowser.find_by_text("1. Kento")
-    assert authbrowser.find_by_text("2. Victor")
-
-
-@then("The ranking should be unchanged")
-def ranking_unchanged(authbrowser):
-    assert authbrowser.find_by_text("1. Victor")
-    assert authbrowser.find_by_text("2. Kento")


### PR DESCRIPTION
fix #35

Done:
- [x] show only 10 matches grouped by date
- [x] show only top 16 of the ranking
- [x] buttons for adding player / match / viewing full ranking or match list
- [x] links for sidebar
- [x] add player / match forms based on same template

To Do:
- [x] update fixtures to have more than 10 matches and multiple on same date
- [x] update fixtures to have more than 16 players in a season
- [x] update tests